### PR TITLE
Fix E487 error by setting tabstop to 0

### DIFF
--- a/autoload/findent.vim
+++ b/autoload/findent.vim
@@ -158,6 +158,13 @@ function! findent#apply(...) abort " {{{
     endif
     return
   endif
+
+  " check the guessed tabstop value because 'tabstop' must be bigger than 0
+  let tabstop = get(meta, 'tabstop', 0)
+  if tabstop <= 0
+    let tabstop = &l:tabstop
+  endif
+
   let meta.previous = {}
   let meta.previous.expandtab   = &l:expandtab
   let meta.previous.shiftwidth  = &l:shiftwidth
@@ -165,7 +172,7 @@ function! findent#apply(...) abort " {{{
   let meta.previous.softtabstop = &l:softtabstop
   let &l:expandtab   = meta.expandtab
   let &l:shiftwidth  = meta.shiftwidth
-  let &l:tabstop     = get(meta, 'tabstop', &l:tabstop)
+  let &l:tabstop     = tabstop
   let &l:softtabstop = get(meta, 'softtabstop', &l:softtabstop)
   let b:_findent = meta
   if options.messages


### PR DESCRIPTION
`findent#guess` may guess `tabstop` as 0 in certain situation and it causes E487 error when applying the guessed values in `findent#apply`.  To fix this, this PR adds the check for the guessed `tabstop` value in `findent#apply`.

### Reproduce steps

- vimrc.vim
```vim
if &compatible
  set nocompatible
endif

set runtimepath^=~/.cache/vim/pack/minpac/opt/vim-findent
runtime! plugin/findent.vim

call setline(1, ["\ttab-indent", "\t  tab-space-indent"])
Findent
```

- Launch vim by `vim -u vimrc.vim`
- You'll get error like this:

```
Error detected while processing /private/tmp/vimrc.vim[9]..function findent#Findent[27]..findent#apply:
line   58:
E487: Argument must be positive
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved handling of `tabstop` value in indentation functionality for enhanced text editing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->